### PR TITLE
1.0.0-alpha9

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cases where correctness must be _"proven"_ (big air quotes).
 ## Installation
 
 ```
-[opticlj "1.0.0-alpha8"]
+[opticlj "1.0.0-alpha9"]
 ```
 
 [See on Clojars](https://clojars.org/opticlj)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject opticlj "1.0.0-alpha8"
+(defproject opticlj "1.0.0-alpha9"
   :description "A Clojure expectation/snapshot testing library, inspired by cram, ppx_expect, and jest"
   :url "http://github.com/lambdahands/opticlj"
   :license {:name "MIT"}

--- a/src/opticlj/writer.cljc
+++ b/src/opticlj/writer.cljc
@@ -21,7 +21,7 @@
 (defn fmt-result [result]
   (if (string? result)
     (str/split (zprint-str result) #"\\n")
-    [(zprint-st result)]))
+    [(zprint-str result)]))
 
 (defn form-output-stream [kw form result]
   (str/join "\n" (concat [(str "(in-ns '" (namespace kw) ")") ""


### PR DESCRIPTION
This PR:
- Fixes a typo regression from `1.0.0-alpha8`